### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT"
 description = "Create a verifiable serial key from a seed"
 
 [dependencies]
-rand = "0.3"
-regex = "0.2"
+rand = "0.8.5"
+regex = "1.5.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,9 +132,9 @@ pub fn check_key(s: &str, blacklist: &Vec<String>, num_bytes: &i8, byte_shifts: 
     let mut checked: Vec<i8> = Vec::new();
 
     for _ in 0..bytes_to_check {
-        let mut byte_to_check = rand::thread_rng().gen_range(0, num_bytes - 1);
+        let mut byte_to_check = rand::thread_rng().gen_range(0..num_bytes - 1);
         while checked.contains(&byte_to_check) {
-            byte_to_check = rand::thread_rng().gen_range(0, num_bytes - 1);
+            byte_to_check = rand::thread_rng().gen_range(0..num_bytes - 1);
         }
         checked.push(byte_to_check);
 


### PR DESCRIPTION
* Bump the `regex` version, as there is a security advisory for that (https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html). 
* Also bump the `rand` to the latest as the changes required is minimum.